### PR TITLE
Re-adds Heroku deployment hooks removed from bugsnag-ruby

### DIFF
--- a/examples/rake/Gemfile
+++ b/examples/rake/Gemfile
@@ -1,1 +1,4 @@
-gem 'bugsnag-capistrano'
+source 'https://rubygems.org'
+
+gem "rake"
+gem "bugsnag-capistrano", path: "../../"

--- a/examples/rake/README.md
+++ b/examples/rake/README.md
@@ -25,9 +25,26 @@ Further details about tracking deploys with Bugsnag can be found [here.](https:/
 
 ## Usage
 
+### Deploying
+
 Run the `bugsnag:deploy` including your API key, release stage, and app version:
 
 ```
 rake bugsnag:deploy BUGSNAG_API_KEY=YOUR-API-KEY \
                     BUGSNAG_RELEASE_STAGE=production
+```
+
+### Adding Heroku hooks
+
+Run the `bugsnag:heroku:add_deploy_hooks` command, including API key, release stage, and app version.
+
+```
+rake bugsnag:heroku:add_deploy_hooks BUGSNAG_API_KEY=YOUR-API-KEY \
+                    BUGSNAG_RELEASE_STAGE=production
+```
+
+If you haave multiple Heroku apps the app to add the hook to can be specified by the `HEROKU_APP` environment variable:
+
+```
+rake bugsnag:heroku:add_deploy_hooks HEROKU_APP=your_heroku_app
 ```

--- a/lib/bugsnag-capistrano/deploy.rb
+++ b/lib/bugsnag-capistrano/deploy.rb
@@ -1,5 +1,6 @@
 require "json"
 require "net/http"
+require "logger"
 
 module Bugsnag
   module Capistrano

--- a/lib/bugsnag-capistrano/tasks/bugsnag-capistrano.rake
+++ b/lib/bugsnag-capistrano/tasks/bugsnag-capistrano.rake
@@ -1,4 +1,4 @@
-require "bugsnag"
+require "bugsnag-capistrano/deploy"
 
 namespace :bugsnag do
 
@@ -10,6 +10,7 @@ namespace :bugsnag do
     revision = ENV["BUGSNAG_REVISION"]
     repository = ENV["BUGSNAG_REPOSITORY"]
     branch = ENV["BUGSNAG_BRANCH"]
+    endpoint = ENV["BUGSNAG_ENDPOINT"]
 
     Rake::Task["load"].invoke unless api_key
     
@@ -19,8 +20,59 @@ namespace :bugsnag do
       :app_version => app_version,
       :revision => revision,
       :repository => repository,
-      :branch => branch
+      :branch => branch,
+      :endpoint => endpoint,
     })
+  end
+
+  namespace :heroku do
+    desc "Add a heroku deploy hook to notify Bugsnag of deploys"
+    task :add_deploy_hook => :load do
+      # Wrapper to run command safely even in bundler
+      run_command = lambda { |command|
+        defined?(Bundler.with_clean_env) ? Bundler.with_clean_env { `#{command}` } : `#{command}`
+      }
+
+      # Fetch heroku config settings
+      config_command = "heroku config --shell"
+      config_command += " --app #{ENV["HEROKU_APP"]}" if ENV["HEROKU_APP"]
+      heroku_env = run_command.call(config_command).split(/[\n\r]/).each_with_object({}) do |c, obj|
+        k,v = c.split("=")
+        obj[k] = (v.nil? || v.strip.empty?) ? nil : v
+      end
+
+      # Check for Bugsnag API key (required) using Bugsnag configuration only if available
+      begin
+        require 'bugsnag'
+        api_key = heroku_env["BUGSNAG_API_KEY"] || Bugsnag.configuration.api_key || ENV["BUGSNAG_API_KEY"]
+      rescue LoadError
+        api_key = heroku_env["BUGSNAG_API_KEY"] || ENV["BUGSNAG_API_KEY"]
+      end
+
+      unless api_key
+        puts "Error: No API key found, have you run 'heroku config:set BUGSNAG_API_KEY=your-api-key'?"
+        next
+      end
+
+      # Build the request, making use of deploy hook variables
+      # (https://devcenter.heroku.com/articles/deploy-hooks#customizing-messages)
+      params = {
+        :apiKey => api_key,
+        :branch => "master",
+        :revision => "{{head_long}}",
+        :releaseStage => heroku_env["RAILS_ENV"] || ENV["RAILS_ENV"] || "production"
+      }
+      repo = `git config --get remote.origin.url`.strip
+      params[:repository] = repo unless repo.empty?
+
+      # Add the hook
+      url = "https://notify.bugsnag.com/deploy?" + params.map {|k,v| "#{k}=#{v}"}.join("&")
+      command = "heroku addons:add deployhooks:http --url=\"#{url}\""
+      command += " --app #{ENV["HEROKU_APP"]}" if ENV["HEROKU_APP"]
+
+      puts "$ #{command}"
+      run_command.call(command)
+    end
   end
 
 end

--- a/spec/rake_spec.rb
+++ b/spec/rake_spec.rb
@@ -1,0 +1,64 @@
+require 'webmock/rspec'
+require 'rspec/expectations'
+require 'rspec/mocks'
+
+require 'webrick'
+
+describe "bugsnag rake", :always do
+
+  server = nil
+  queue = Queue.new
+  fixture_path = '../examples/rake'
+  exec_string = 'bundle exec rake bugsnag:deploy'
+  example_path = File.join(File.dirname(__FILE__), fixture_path)
+
+  before do
+    server = WEBrick::HTTPServer.new :Port => 0, :Logger => WEBrick::Log.new(STDOUT), :AccessLog => []
+    server.mount_proc '/deploy' do |req, res|
+      queue.push req.body
+      res.status = 200
+      res.body = "OK\n"
+    end
+    Thread.new{ server.start }
+  end
+
+  after do
+    server.stop
+    queue.clear
+  end
+
+  let(:request) { JSON.parse(queue.pop) }
+  
+  it "sends a deploy notification to the set endpoint" do
+    ENV['BUGSNAG_ENDPOINT'] = "http://localhost:" + server.config[:Port].to_s + "/deploy"
+    ENV['BUGSNAG_API_KEY'] = "YOUR_API_KEY"
+    
+    Dir.chdir(example_path) do
+      system(exec_string)
+    end
+
+    payload = request()
+    expect(payload["apiKey"]).to eq('YOUR_API_KEY')
+  end
+
+  it "allows modifications of deployment characteristics" do
+    ENV['BUGSNAG_ENDPOINT'] = "http://localhost:" + server.config[:Port].to_s + "/deploy"
+    ENV['BUGSNAG_API_KEY'] = "this is a test key"
+    ENV['BUGSNAG_RELEASE_STAGE'] = "test"
+    ENV['BUGSNAG_REVISION'] = "test"
+    ENV['BUGSNAG_APP_VERSION'] = "1"
+    ENV['BUGSNAG_REPOSITORY'] = "test@repo.com:test/test_repo.git"
+
+    Dir.chdir(example_path) do
+      system(exec_string)
+    end
+
+    payload = request()
+    expect(payload["apiKey"]).to eq('this is a test key')
+    expect(payload["releaseStage"]).to eq('test')
+    expect(payload["repository"]).to eq("test@repo.com:test/test_repo.git")
+    expect(payload["appVersion"]).to eq("1")
+    expect(payload["revision"]).to eq("test")
+  end
+end
+


### PR DESCRIPTION
- Adds the deployment hooks from `bugsnag-ruby` back into the `bugsnag-capistrano` repo.
- Updates rake example with explanation of Heroku deployment.
- Fixes issue with bugsnag-capistrano not requiring logger before use
- Ensures rake task can work standalone (without bugsnag-ruby installed)