### PR TITLE
BUGSNAG_RELEASE_STAGE should be before RAILS_ENV

### DIFF
--- a/lib/bugsnag-capistrano/tasks/bugsnag-capistrano.rake
+++ b/lib/bugsnag-capistrano/tasks/bugsnag-capistrano.rake
@@ -60,7 +60,7 @@ namespace :bugsnag do
         :apiKey => api_key,
         :branch => "master",
         :revision => "{{head_long}}",
-        :releaseStage => heroku_env["RAILS_ENV"] || ENV["RAILS_ENV"] || "production"
+        :releaseStage => heroku_env["BUGSNAG_RELEASE_STAGE"] || heroku_env["RAILS_ENV"] || ENV["RAILS_ENV"] || "production"
       }
       repo = `git config --get remote.origin.url`.strip
       params[:repository] = repo unless repo.empty?


### PR DESCRIPTION
We should give an option to have release stage different from rails env when run `rake bugsnag:heroku:add_deploy_hook`.

I'm just curious, why does this task `bugsnag:heroku:add_deploy_hook` live in this `bugsnag-capistrano`? I look at task, it doesn't depend on anything in bugsnag-capistrano gem itself. Currently there is one problem, when add `gem 'bugsnag-capistrano'` in Gemfile and run `rake bugsnag:heroku:add_deploy_hook`, it will try to load the gem and it failed because it loaded the gem and reference to Capistrano here https://github.com/bugsnag/bugsnag-capistrano/blob/3175b0d22c358ac64f826e8b697c745a545e222e/lib/bugsnag-capistrano/capistrano2.rb#L32. I have to update in Gemfile to `gem 'bugsnag-capistrano', require: false`, so that I can run the task.