### PR TITLE
Stop loading capistrano tasks if capistrano isn't defined

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 group :test, optional: true do
   gem 'rake', '~> 10.1.1'
   gem 'rspec'
-  gem 'rdoc'
+  gem 'rdoc', RUBY_VERSION <= '2.2.2' ? '5.1.0': '>5.1.0'
   gem 'pry'
   gem 'addressable', '~>2.3.8'
   gem 'webmock', RUBY_VERSION <= '1.9.3' ? '2.3.2': '>2.3.2'

--- a/lib/bugsnag-capistrano/capistrano.rb
+++ b/lib/bugsnag-capistrano/capistrano.rb
@@ -1,6 +1,8 @@
 require_relative "deploy"
 
-if defined?(Capistrano::VERSION) && Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
+if !defined?(Capistrano)
+  return
+elsif defined?(Capistrano::VERSION) && Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
   load File.expand_path('../tasks/bugsnag.cap', __FILE__)
 else
   require_relative 'capistrano2'

--- a/lib/bugsnag-capistrano/capistrano.rb
+++ b/lib/bugsnag-capistrano/capistrano.rb
@@ -1,9 +1,7 @@
 require_relative "deploy"
 
-if !defined?(Capistrano)
-  return
-elsif defined?(Capistrano::VERSION) && Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
+if defined?(Capistrano::VERSION) && Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
   load File.expand_path('../tasks/bugsnag.cap', __FILE__)
-else
+elsif defined?(Capistrano)
   require_relative 'capistrano2'
 end


### PR DESCRIPTION
When used in rails & rake together, Rake tries to load the capistrano tasks, throwing an error as described in [#409](https://github.com/bugsnag/bugsnag-ruby/issues/409).

This PR will stop these tasks being loaded if Capistrano is not defined.