### PR TITLE
Fix double JSON.dump with Bugsnag 6

### DIFF
--- a/lib/bugsnag-capistrano/deploy.rb
+++ b/lib/bugsnag-capistrano/deploy.rb
@@ -46,6 +46,11 @@ module Bugsnag
 
         raise RuntimeError.new("No API key found when notifying of deploy") if !parameters["apiKey"] || parameters["apiKey"].empty?
 
+        if Gem::Version.new(Bugsnag::VERSION).release >= Gem::Version.new('6.0.0')
+          payload_string = parameters
+        else
+          payload_string = ::JSON.dump(parameters)
+        end
 
         payload_string = ::JSON.dump(parameters)
         Bugsnag::Delivery::Synchronous.deliver(endpoint, payload_string, configuration)


### PR DESCRIPTION
In [Bugsnag 6](https://github.com/bugsnag/bugsnag-ruby/blob/master/lib/bugsnag/delivery/synchronous.rb#L37) `Bugsnag::Delivery::Synchronous.deliver` calls `JSON.dump` on `body`, this causes the request to fail with 400 because we are also doing the same operation.

This gem still doesn't have any integration tests, do you plan adding integrations tests? I think it would be really helpful to run tests on a Rails app to ensure the common use cases work.
  