### PR TITLE
Use default deploy endpoint when no endpoint is sent

### DIFF
--- a/lib/bugsnag-capistrano/deploy.rb
+++ b/lib/bugsnag-capistrano/deploy.rb
@@ -30,7 +30,7 @@ module Bugsnag
         end
 
         if Gem::Version.new(Bugsnag::VERSION).release >= Gem::Version.new('6.0.0')
-          endpoint = configuration.endpoint
+          endpoint = opts[:endpoint].nil? ? DEFAULT_DEPLOY_ENDPOINT : configuration.endpoint
         else
           endpoint = (configuration.use_ssl ? "https://" : "http://") + configuration.endpoint
         end


### PR DESCRIPTION
When no value is sent `opts[:endpoint]`, then  `configuration.endpoint` will be `https://notify.bugsnag.com` but we need to use the deploy endpoint `https://notify.bugsnag.com/deploy`.