### PR TITLE
Update to build API

### DIFF
--- a/lib/bugsnag-capistrano/capistrano2.rb
+++ b/lib/bugsnag-capistrano/capistrano2.rb
@@ -14,9 +14,10 @@ module Bugsnag
                 :release_stage => fetch(:bugsnag_env) || ENV["BUGSNAG_RELEASE_STAGE"] || fetch(:rails_env) || fetch(:stage) || "production",
                 :revision => fetch(:current_revision, ENV["BUGSNAG_REVISION"]),
                 :repository => fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"]),
-                :branch => fetch(:branch, ENV["BUGSNAG_BRANCH"]),
+                :provider => fetch(:provider, ENV["BUGSNAG_BRANCH"]),
                 :app_version => fetch(:app_version, ENV["BUGSNAG_APP_VERSION"]),
-                :endpoint => fetch(:bugsnag_endpoint)
+                :endpoint => fetch(:bugsnag_endpoint),
+                :builder => fetch(:builder)
               })
               logger.info "Bugsnag deploy notification complete."
             rescue

--- a/lib/bugsnag-capistrano/capistrano2.rb
+++ b/lib/bugsnag-capistrano/capistrano2.rb
@@ -17,7 +17,7 @@ module Bugsnag
                 :provider => fetch(:provider, ENV["BUGSNAG_BRANCH"]),
                 :app_version => fetch(:app_version, ENV["BUGSNAG_APP_VERSION"]),
                 :endpoint => fetch(:bugsnag_endpoint),
-                :builder => fetch(:builder)
+                :builder => fetch(:builder, ENV["BUGSNAG_BUILDER"])
               })
               logger.info "Bugsnag deploy notification complete."
             rescue

--- a/lib/bugsnag-capistrano/capistrano2.rb
+++ b/lib/bugsnag-capistrano/capistrano2.rb
@@ -14,7 +14,7 @@ module Bugsnag
                 :release_stage => fetch(:bugsnag_env) || ENV["BUGSNAG_RELEASE_STAGE"] || fetch(:rails_env) || fetch(:stage) || "production",
                 :revision => fetch(:current_revision, ENV["BUGSNAG_REVISION"]),
                 :repository => fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"]),
-                :provider => fetch(:provider, ENV["BUGSNAG_BRANCH"]),
+                :provider => fetch(:provider, ENV["BUGSNAG_PROVIDER"]),
                 :app_version => fetch(:app_version, ENV["BUGSNAG_APP_VERSION"]),
                 :endpoint => fetch(:bugsnag_endpoint),
                 :builder => fetch(:builder, ENV["BUGSNAG_BUILDER"])

--- a/lib/bugsnag-capistrano/tasks/bugsnag-capistrano.rake
+++ b/lib/bugsnag-capistrano/tasks/bugsnag-capistrano.rake
@@ -9,19 +9,21 @@ namespace :bugsnag do
     app_version = ENV["BUGSNAG_APP_VERSION"]
     revision = ENV["BUGSNAG_REVISION"]
     repository = ENV["BUGSNAG_REPOSITORY"]
-    branch = ENV["BUGSNAG_BRANCH"]
+    provider = ENV["BUGSNAG_PROVIDER"]
     endpoint = ENV["BUGSNAG_ENDPOINT"]
+    builder = ENV["BUGSNAG_BUILDER"]
 
     Rake::Task["load"].invoke unless api_key
-    
+
     Bugsnag::Capistrano::Deploy.notify({
       :api_key => api_key,
       :release_stage => release_stage,
       :app_version => app_version,
       :revision => revision,
       :repository => repository,
-      :branch => branch,
+      :provider => provider,
       :endpoint => endpoint,
+      :builder => builder,
     })
   end
 
@@ -60,13 +62,15 @@ namespace :bugsnag do
         :apiKey => api_key,
         :branch => "master",
         :revision => "{{head_long}}",
-        :releaseStage => heroku_env["BUGSNAG_RELEASE_STAGE"] || heroku_env["RAILS_ENV"] || ENV["RAILS_ENV"] || "production"
+        :releaseStage => heroku_env["BUGSNAG_RELEASE_STAGE"] || heroku_env["RAILS_ENV"] || ENV["RAILS_ENV"] || "production",
+        :provider => heroku_env["BUGSNAG_PROVIDER"],
+        :builder => heroku_env["BUGSNAG_BUILDER"] || %x(whoami)
       }
       repo = `git config --get remote.origin.url`.strip
       params[:repository] = repo unless repo.empty?
 
       # Add the hook
-      url = "https://notify.bugsnag.com/deploy?" + params.map {|k,v| "#{k}=#{v}"}.join("&")
+      url = "https://build.bugsnag.com?" + params.map {|k,v| "#{k}=#{v}"}.join("&")
       command = "heroku addons:add deployhooks:http --url=\"#{url}\""
       command += " --app #{ENV["HEROKU_APP"]}" if ENV["HEROKU_APP"]
 

--- a/lib/bugsnag-capistrano/tasks/bugsnag.cap
+++ b/lib/bugsnag-capistrano/tasks/bugsnag.cap
@@ -31,9 +31,10 @@ namespace :bugsnag do
           :release_stage => fetch(:bugsnag_env) || ENV["BUGSNAG_RELEASE_STAGE"] || fetch(:rails_env) || fetch(:stage) || "production",
           :revision => fetch(:current_revision, ENV["BUGSNAG_REVISION"]),
           :repository => fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"]),
-          :branch => fetch(:branch, ENV["BUGSNAG_BRANCH"]),
+          :provider => fetch(:provider, ENV["BUGSNAG_BRANCH"]),
           :app_version => fetch(:app_version, ENV["BUGSNAG_APP_VERSION"]),
-          :endpoint => fetch(:bugsnag_endpoint)
+          :endpoint => fetch(:bugsnag_endpoint),
+          :builder => fetch(:builder, ENV["BUGSNAG_BUILDER"])
         })
         info 'Bugsnag deploy notification complete.'
       rescue

--- a/lib/bugsnag-capistrano/tasks/bugsnag.cap
+++ b/lib/bugsnag-capistrano/tasks/bugsnag.cap
@@ -31,7 +31,7 @@ namespace :bugsnag do
           :release_stage => fetch(:bugsnag_env) || ENV["BUGSNAG_RELEASE_STAGE"] || fetch(:rails_env) || fetch(:stage) || "production",
           :revision => fetch(:current_revision, ENV["BUGSNAG_REVISION"]),
           :repository => fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"]),
-          :provider => fetch(:provider, ENV["BUGSNAG_BRANCH"]),
+          :provider => fetch(:provider, ENV["BUGSNAG_PROVIDER"]),
           :app_version => fetch(:app_version, ENV["BUGSNAG_APP_VERSION"]),
           :endpoint => fetch(:bugsnag_endpoint),
           :builder => fetch(:builder, ENV["BUGSNAG_BUILDER"])

--- a/spec/capistrano_spec.rb
+++ b/spec/capistrano_spec.rb
@@ -64,6 +64,7 @@ describe "bugsnag capistrano", :always do
       "revision" => "test"
     })
     expect(payload["builderName"]).to eq("testbuilder")
+    expect(payload["buildTool"]).to eq("bugsnag-capistrano")
   end
 end
 

--- a/spec/capistrano_spec.rb
+++ b/spec/capistrano_spec.rb
@@ -29,10 +29,10 @@ describe "bugsnag capistrano", :always do
   end
 
   let(:request) { JSON.parse(queue.pop) }
-  
+
   it "sends a deploy notification to the set endpoint" do
     ENV['BUGSNAG_ENDPOINT'] = "http://localhost:" + server.config[:Port].to_s + "/deploy"
-    
+
     Dir.chdir(example_path) do
       system(exec_string)
     end
@@ -49,6 +49,7 @@ describe "bugsnag capistrano", :always do
     ENV['BUGSNAG_REVISION'] = "test"
     ENV['BUGSNAG_APP_VERSION'] = "1"
     ENV['BUGSNAG_REPOSITORY'] = "test@repo.com:test/test_repo.git"
+    ENV['BUGSNAG_BUILDER'] = "testbuilder"
 
     Dir.chdir(example_path) do
       system(exec_string)
@@ -57,9 +58,12 @@ describe "bugsnag capistrano", :always do
     payload = request()
     expect(payload["apiKey"]).to eq('this is a test key')
     expect(payload["releaseStage"]).to eq('test')
-    expect(payload["repository"]).to eq("test@repo.com:test/test_repo.git")
     expect(payload["appVersion"]).to eq("1")
-    expect(payload["revision"]).to eq("test")
+    expect(payload["sourceControl"]).to eq({
+      "repository" => "test@repo.com:test/test_repo.git",
+      "revision" => "test"
+    })
+    expect(payload["builderName"]).to eq("testbuilder")
   end
 end
 

--- a/spec/capistrano_spec.rb
+++ b/spec/capistrano_spec.rb
@@ -50,6 +50,7 @@ describe "bugsnag capistrano", :always do
     ENV['BUGSNAG_APP_VERSION'] = "1"
     ENV['BUGSNAG_REPOSITORY'] = "test@repo.com:test/test_repo.git"
     ENV['BUGSNAG_BUILDER'] = "testbuilder"
+    ENV['BUGSNAG_PROVIDER'] = "github"
 
     Dir.chdir(example_path) do
       system(exec_string)
@@ -61,7 +62,8 @@ describe "bugsnag capistrano", :always do
     expect(payload["appVersion"]).to eq("1")
     expect(payload["sourceControl"]).to eq({
       "repository" => "test@repo.com:test/test_repo.git",
-      "revision" => "test"
+      "revision" => "test",
+      "provider" => "github"
     })
     expect(payload["builderName"]).to eq("testbuilder")
     expect(payload["buildTool"]).to eq("bugsnag-capistrano")

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -23,9 +23,9 @@ describe Bugsnag::Capistrano::Deploy do
     after do
       Bugsnag.configuration.clear_request_data
     end
-    
+
     it "should call notify_with_bugsnag" do
-      expect(Bugsnag::Delivery::Synchronous).to receive(:deliver)
+      expect(Bugsnag::Capistrano::Deploy).to receive(:deliver)
       Bugsnag::Capistrano::Deploy.notify()
     end
   end
@@ -34,6 +34,14 @@ describe Bugsnag::Capistrano::Deploy do
     it "should call notify_without bugsnag" do
       expect(Bugsnag::Capistrano::Deploy).to receive(:deliver)
       Bugsnag::Capistrano::Deploy.notify({:api_key => "test"})
+    end
+  end
+
+  describe "the get_provider function", :always do
+    it "returns the correct providers" do
+      expect(Bugsnag::Capistrano::Deploy.get_provider('git://github.com/test/test')).to eq('github')
+      expect(Bugsnag::Capistrano::Deploy.get_provider('https://test.bitbucket.com/test/test')).to eq('bitbucket')
+      expect(Bugsnag::Capistrano::Deploy.get_provider('https://gitlab.com/test/test')).to eq('gitlab')
     end
   end
 

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -37,14 +37,6 @@ describe Bugsnag::Capistrano::Deploy do
     end
   end
 
-  describe "the get_provider function", :always do
-    it "returns the correct providers" do
-      expect(Bugsnag::Capistrano::Deploy.get_provider('git://github.com/test/test')).to eq('github')
-      expect(Bugsnag::Capistrano::Deploy.get_provider('https://test.bitbucket.com/test/test')).to eq('bitbucket')
-      expect(Bugsnag::Capistrano::Deploy.get_provider('https://gitlab.com/test/test')).to eq('gitlab')
-    end
-  end
-
   describe "the delivery function", :always do
     it "delivers a request to the given url" do
       url = "http://localhost:56456"

--- a/spec/rake_spec.rb
+++ b/spec/rake_spec.rb
@@ -63,6 +63,7 @@ describe "bugsnag rake", :always do
       "revision" => "test"
     })
     expect(payload["builderName"]).to eq("testbuilder")
+    expect(payload["buildTool"]).to eq("bugsnag-capistrano")
   end
 end
 

--- a/spec/rake_spec.rb
+++ b/spec/rake_spec.rb
@@ -49,6 +49,7 @@ describe "bugsnag rake", :always do
     ENV['BUGSNAG_APP_VERSION'] = "1"
     ENV['BUGSNAG_REPOSITORY'] = "test@repo.com:test/test_repo.git"
     ENV['BUGSNAG_BUILDER'] = "testbuilder"
+    ENV["BUGSNAG_PROVIDER"] = "github"
 
     Dir.chdir(example_path) do
       system(exec_string)
@@ -60,7 +61,8 @@ describe "bugsnag rake", :always do
     expect(payload["appVersion"]).to eq("1")
     expect(payload["sourceControl"]).to eq({
       "repository" => "test@repo.com:test/test_repo.git",
-      "revision" => "test"
+      "revision" => "test",
+      "provider" => "github"
     })
     expect(payload["builderName"]).to eq("testbuilder")
     expect(payload["buildTool"]).to eq("bugsnag-capistrano")

--- a/spec/rake_spec.rb
+++ b/spec/rake_spec.rb
@@ -28,11 +28,11 @@ describe "bugsnag rake", :always do
   end
 
   let(:request) { JSON.parse(queue.pop) }
-  
+
   it "sends a deploy notification to the set endpoint" do
     ENV['BUGSNAG_ENDPOINT'] = "http://localhost:" + server.config[:Port].to_s + "/deploy"
     ENV['BUGSNAG_API_KEY'] = "YOUR_API_KEY"
-    
+
     Dir.chdir(example_path) do
       system(exec_string)
     end
@@ -48,6 +48,7 @@ describe "bugsnag rake", :always do
     ENV['BUGSNAG_REVISION'] = "test"
     ENV['BUGSNAG_APP_VERSION'] = "1"
     ENV['BUGSNAG_REPOSITORY'] = "test@repo.com:test/test_repo.git"
+    ENV['BUGSNAG_BUILDER'] = "testbuilder"
 
     Dir.chdir(example_path) do
       system(exec_string)
@@ -56,9 +57,12 @@ describe "bugsnag rake", :always do
     payload = request()
     expect(payload["apiKey"]).to eq('this is a test key')
     expect(payload["releaseStage"]).to eq('test')
-    expect(payload["repository"]).to eq("test@repo.com:test/test_repo.git")
     expect(payload["appVersion"]).to eq("1")
-    expect(payload["revision"]).to eq("test")
+    expect(payload["sourceControl"]).to eq({
+      "repository" => "test@repo.com:test/test_repo.git",
+      "revision" => "test"
+    })
+    expect(payload["builderName"]).to eq("testbuilder")
   end
 end
 


### PR DESCRIPTION
Updates Capistrano, Rake & Heroku to use the new build api endpoint.
- Uses local deploy command for delivery instead of Bugsnag::Delivery
- Acquires `builderName` from `%x(whoami)` if not provided