### PR TITLE
fix(deploy): Make deployment notifications go to the correct endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD
+
+### Fixes
+
+* Fixes a case where deployment notifications were delivered to an incorrect
+  endpoint, causing them to not appear on the dashboard timeline
+
 ## 1.1.1 (14-12-2017)
 
 ### Fixes

--- a/lib/bugsnag-capistrano/deploy.rb
+++ b/lib/bugsnag-capistrano/deploy.rb
@@ -30,9 +30,9 @@ module Bugsnag
         end
 
         if Gem::Version.new(Bugsnag::VERSION).release >= Gem::Version.new('6.0.0')
-          endpoint = configuration.endpoint
+          endpoint = configuration.endpoint + '/deploy'
         else
-          endpoint = (configuration.use_ssl ? "https://" : "http://") + configuration.endpoint
+          endpoint = (configuration.use_ssl ? "https://" : "http://") + configuration.endpoint + '/deploy'
         end
 
         parameters = {


### PR DESCRIPTION
## Goal

This is a patch to the 1.x branch to ensure that when the `bugsnag` gem is installed/active, deployment notifications use the correct endpoint. 

## Changeset

### Changed

* Updated how endpoint is calculated in `deploy.rb` for the "with bugsnag" path

## Tests

* Added tests for the default endpoint behavior

## Discussion

Barring any critical failures, this is likely the last patch to the 1.x release series

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
