### PR TITLE
Fix require statement in examples

### DIFF
--- a/examples/capistrano2/README.md
+++ b/examples/capistrano2/README.md
@@ -13,7 +13,7 @@ bundle install
 
 1. In the `Capfile`, require the bugsnag-capistrano library.
 ```ruby
-require 'bugsnag/capistrano'
+require 'bugsnag-capistrano'
 ```
 
 2. Then in the same file set the `:bugsnag_api_key` to your api key

--- a/examples/capistrano3/README.md
+++ b/examples/capistrano3/README.md
@@ -13,7 +13,7 @@ bundle install
 
 1. In the `Capfile`, require the bugsnag-capistrano library.
 ```ruby
-require 'bugsnag/capistrano'
+require 'bugsnag-capistrano'
 ```
 
 2. Then in the same file set the `:bugsnag_api_key` to your api key


### PR DESCRIPTION
The README files for the examples show a require statement that is incorrect. This updates them to be correct and consistent with our other documentation.

Thanks to @aimee-ault for noticing!