### PR TITLE
Allow to pass bugsnag repo url

### DIFF
--- a/lib/bugsnag-capistrano/capistrano2.rb
+++ b/lib/bugsnag-capistrano/capistrano2.rb
@@ -17,7 +17,7 @@ module Bugsnag
                 :metadata => fetch(:bugsnag_metadata, nil),
                 :release_stage => fetch(:bugsnag_env) || ENV["BUGSNAG_RELEASE_STAGE"] || fetch(:rails_env) || fetch(:stage) || "production",
                 :revision => fetch(:current_revision, ENV["BUGSNAG_REVISION"]),
-                :repository => fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"]),
+                :repository => fetch(:bugsnag_repo_url, fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"])),
                 :source_control_provider => fetch(:bugsnag_source_control_provider, ENV["BUGSNAG_SOURCE_CONTROL_PROVIDER"]),
                 :endpoint => fetch(:bugsnag_endpoint, nil)
               })

--- a/lib/bugsnag-capistrano/tasks/bugsnag.cap
+++ b/lib/bugsnag-capistrano/tasks/bugsnag.cap
@@ -28,7 +28,7 @@ namespace :bugsnag do
           :metadata => fetch(:bugsnag_metadata),
           :release_stage => fetch(:bugsnag_env) || ENV["BUGSNAG_RELEASE_STAGE"] || fetch(:rails_env) || fetch(:stage) || "production",
           :revision => fetch(:current_revision, ENV["BUGSNAG_REVISION"]),
-          :repository => fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"]),
+          :repository => fetch(:bugsnag_repo_url, fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"])),,
           :source_control_provider => fetch(:bugsnag_source_control_provider, ENV["BUGSNAG_SOURCE_CONTROL_PROVIDER"]),
           :endpoint => fetch(:bugsnag_endpoint)
         })


### PR DESCRIPTION
This is useful when you want to pass the make a release with source
controll link, with the git relo cloned with ssh but the the gui
expect a http ref

The repo url could be either
	git@github.com:stoivo/bugsnag-capistrano.git
	https://github.com/stoivo/bugsnag-capistrano.git

In my case I use gitlab-onpremise and the params passed to

```
{"apiKey"=>"...",
 "appVersion"=>"...",
 "autoAssignRelease"=>..,
 "builderName"=>"...",
 "buildTool"=>"..",
 "metadata"=>nil,
 "releaseStage"=>"staging",
 "sourceControl"=>
  {"provider"=>"gitlab-onpremise",
   "revision"=>"SHA",
   "repository"=>"https://gitlab.url/org/repo/"}}
```
This might be a bug on the bugsnag server side but this fixes it on the client

## Goal

Make source link work for gitlab on premis wit repo url using git

## Design

Added a config variable

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->