### PR TITLE
Move logic out of spec files and into helpers

### DIFF
--- a/spec/capistrano_spec.rb
+++ b/spec/capistrano_spec.rb
@@ -1,51 +1,27 @@
-require 'webmock/rspec'
-require 'rspec/expectations'
-require 'rspec/mocks'
-
-require 'webrick'
+require_relative './spec_helper'
 
 describe "bugsnag capistrano" do
+  server = Helpers::Server.new
 
-  server = nil
-  queue = Queue.new
-  cap_2 = ENV['CAP_2_TEST'] == 'true'
-  fixture_path = cap_2 ? '../examples/capistrano2' : '../examples/capistrano3'
-  exec_string = cap_2 ? 'bundle exec cap deploy' : 'bundle exec cap test deploy'
-  example_path = File.join(File.dirname(__FILE__), fixture_path)
-
-  before do
-    server = WEBrick::HTTPServer.new :Port => 0, :Logger => WEBrick::Log.new(STDOUT), :AccessLog => []
-    server.mount_proc '/deploy' do |req, res|
-      queue.push req.body
-      res.status = 200
-      res.body = "OK\n"
-    end
-    Thread.new{ server.start }
-  end
-
-  after do
-    server.stop
-    queue.clear
-  end
-
-  let(:request) { JSON.parse(queue.pop) }
+  before { server.start }
+  after { server.stop }
 
   it "sends a deploy notification to the set endpoint" do
-    ENV['BUGSNAG_ENDPOINT'] = "http://localhost:" + server.config[:Port].to_s + "/deploy"
+    ENV['BUGSNAG_ENDPOINT'] = server.url
     ENV['BUGSNAG_APP_VERSION'] = "1"
 
-    Dir.chdir(example_path) do
-      system(exec_string)
+    Dir.chdir(Helpers::Capistrano.example_path) do
+      system(Helpers::Capistrano.deploy_command)
     end
 
-    payload = request()
+    payload = server.last_request
     expect(payload["apiKey"]).to eq('YOUR_API_KEY')
     expect(payload["appVersion"]).to eq("1")
     expect(payload["releaseStage"]).to eq('production')
   end
 
   it "allows modifications of deployment characteristics" do
-    ENV['BUGSNAG_ENDPOINT'] = "http://localhost:" + server.config[:Port].to_s + "/deploy"
+    ENV['BUGSNAG_ENDPOINT'] = server.url
     ENV['BUGSNAG_API_KEY'] = "this is a test key"
     ENV['BUGSNAG_RELEASE_STAGE'] = "test"
     ENV['BUGSNAG_REVISION'] = "test"
@@ -54,11 +30,11 @@ describe "bugsnag capistrano" do
     ENV['BUGSNAG_SOURCE_CONTROL_PROVIDER'] = "github"
     ENV['BUGSNAG_AUTO_ASSIGN_RELEASE'] = 'true'
 
-    Dir.chdir(example_path) do
-      system(exec_string)
+    Dir.chdir(Helpers::Capistrano.example_path) do
+      system(Helpers::Capistrano.deploy_command)
     end
 
-    payload = request()
+    payload = server.last_request
     expect(payload["apiKey"]).to eq('this is a test key')
     expect(payload["releaseStage"]).to eq('test')
     expect(payload["appVersion"]).to eq("1")
@@ -69,4 +45,3 @@ describe "bugsnag capistrano" do
     expect(payload["autoAssignRelease"]).to eq(true)
   end
 end
-

--- a/spec/helpers/capistrano.rb
+++ b/spec/helpers/capistrano.rb
@@ -1,0 +1,22 @@
+require 'tmpdir'
+require 'fileutils'
+
+module Helpers
+  class Capistrano
+    def self.version_2?
+      ENV['CAP_2_TEST'] == 'true'
+    end
+
+    def self.deploy_command
+      return 'bundle exec cap deploy' if version_2?
+
+      'bundle exec cap test deploy'
+    end
+
+    def self.example_path
+      fixture_path = version_2? ? '../../examples/capistrano2' : '../../examples/capistrano3'
+
+      File.join(File.dirname(__FILE__), fixture_path)
+    end
+  end
+end

--- a/spec/helpers/server.rb
+++ b/spec/helpers/server.rb
@@ -1,0 +1,63 @@
+require 'json'
+require 'webrick'
+
+module Helpers
+  class Server
+    def initialize
+      @queue = Queue.new
+      @server = nil
+      @thread = nil
+    end
+
+    def start
+      @server = WEBrick::HTTPServer.new({
+        Port: 0,
+        Logger: WEBrick::Log.new(STDOUT),
+        AccessLog: []
+      })
+
+      @server.mount_proc('/deploy') do |req, res|
+        @queue.push(req.body)
+
+        res.status = 200
+        res.body = "OK\n"
+      end
+
+      @thread = Thread.new { @server.start }
+
+      loop do
+        break if @server.status == :Running
+
+        sleep(0.1)
+      end
+    end
+
+    def stop
+      @queue.clear
+      @server.stop
+      @thread.join(5)
+      @server = nil
+    end
+
+    def url
+      raise "Server is not running!" if @server.nil?
+
+      "http://localhost:" + @server.config[:Port].to_s + "/deploy"
+    end
+
+    def last_request
+      retries = 0
+
+      begin
+        JSON.parse(@queue.pop(true))
+      rescue ThreadError
+        raise if retries >= 10
+
+        retries += 1
+        sleep(0.1)
+
+        retry
+      end
+    end
+  end
+end

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -1,10 +1,8 @@
-require 'webmock/rspec'
+require_relative './spec_helper'
+
 require 'rspec/expectations'
 require 'rspec/mocks'
-require 'logger'
-require 'json'
-
-require 'webrick'
+require 'webmock/rspec'
 
 require 'bugsnag-capistrano/release'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require_relative './helpers/server'
+require_relative './helpers/capistrano'


### PR DESCRIPTION
## Goal

This PR contains some preparatory refactoring to the specs — primarily moving the logic that was at the top of `capistrano_spec.rb` into separate helper classes

This also fixes a couple of bugs in the previous implementation, most notably a hang if no request was sent due to using the blocking `queue.pop` in the main thread