### PR TITLE
Allow using a Bugsnag-specific repo URL

### DIFF
--- a/lib/bugsnag-capistrano/capistrano2.rb
+++ b/lib/bugsnag-capistrano/capistrano2.rb
@@ -17,7 +17,7 @@ module Bugsnag
                 :metadata => fetch(:bugsnag_metadata, nil),
                 :release_stage => fetch(:bugsnag_env) || ENV["BUGSNAG_RELEASE_STAGE"] || fetch(:rails_env) || fetch(:stage) || "production",
                 :revision => fetch(:current_revision, ENV["BUGSNAG_REVISION"]),
-                :repository => fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"]),
+                :repository => fetch(:bugsnag_repo_url, fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"])),
                 :source_control_provider => fetch(:bugsnag_source_control_provider, ENV["BUGSNAG_SOURCE_CONTROL_PROVIDER"]),
                 :endpoint => fetch(:bugsnag_endpoint, nil)
               })

--- a/lib/bugsnag-capistrano/tasks/bugsnag.cap
+++ b/lib/bugsnag-capistrano/tasks/bugsnag.cap
@@ -28,7 +28,7 @@ namespace :bugsnag do
           :metadata => fetch(:bugsnag_metadata),
           :release_stage => fetch(:bugsnag_env) || ENV["BUGSNAG_RELEASE_STAGE"] || fetch(:rails_env) || fetch(:stage) || "production",
           :revision => fetch(:current_revision, ENV["BUGSNAG_REVISION"]),
-          :repository => fetch(:bugsnag_repo_url, fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"])),,
+          :repository => fetch(:bugsnag_repo_url, fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"])),
           :source_control_provider => fetch(:bugsnag_source_control_provider, ENV["BUGSNAG_SOURCE_CONTROL_PROVIDER"]),
           :endpoint => fetch(:bugsnag_endpoint)
         })

--- a/lib/bugsnag-capistrano/tasks/bugsnag.cap
+++ b/lib/bugsnag-capistrano/tasks/bugsnag.cap
@@ -28,7 +28,7 @@ namespace :bugsnag do
           :metadata => fetch(:bugsnag_metadata),
           :release_stage => fetch(:bugsnag_env) || ENV["BUGSNAG_RELEASE_STAGE"] || fetch(:rails_env) || fetch(:stage) || "production",
           :revision => fetch(:current_revision, ENV["BUGSNAG_REVISION"]),
-          :repository => fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"]),
+          :repository => fetch(:bugsnag_repo_url, fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"])),,
           :source_control_provider => fetch(:bugsnag_source_control_provider, ENV["BUGSNAG_SOURCE_CONTROL_PROVIDER"]),
           :endpoint => fetch(:bugsnag_endpoint)
         })

--- a/spec/capistrano_spec.rb
+++ b/spec/capistrano_spec.rb
@@ -44,4 +44,73 @@ describe "bugsnag capistrano" do
     expect(payload["sourceControl"]["provider"]).to eq("github")
     expect(payload["autoAssignRelease"]).to eq(true)
   end
+
+  it "uses 'repo_url' in preference to 'BUGSNAG_REPOSITORY'" do
+    ENV['BUGSNAG_REPOSITORY'] = "unused@repo.com:unused/unused_repo.git"
+
+    capfile = Helpers::Capistrano.generate_capfile({
+      bugsnag_api_key: "this is a test key",
+      app_version: "1",
+      bugsnag_auto_assign_release: true,
+      bugsnag_builder: "bob",
+      bugsnag_metadata: { a: 1, b: 2 },
+      bugsnag_env: "test",
+      current_revision: "test1234",
+      repo_url: "test@repo.com:test/test_repo.git",
+      bugsnag_source_control_provider: "github",
+      bugsnag_endpoint: server.url,
+    })
+
+    Helpers::Capistrano.run(capfile)
+
+    payload = server.last_request
+
+    expect(payload["apiKey"]).to eq('this is a test key')
+    expect(payload["appVersion"]).to eq("1")
+    expect(payload["autoAssignRelease"]).to eq(true)
+    expect(payload["builderName"]).to eq("bob")
+    expect(payload["buildTool"]).to eq("bugsnag-capistrano")
+    expect(payload["metadata"]).to eq({ "a" => 1, "b" => 2 })
+    expect(payload["releaseStage"]).to eq("test")
+    expect(payload["sourceControl"]).to eq({
+      "revision" => "test1234",
+      "repository" => "test@repo.com:test/test_repo.git",
+      "provider" => "github",
+    })
+  end
+
+  it "uses 'bugsnag_repo_url' in preference to 'repo_url'" do
+    ENV['BUGSNAG_REPOSITORY'] = "unused@repo.com:unused/unused_repo.git"
+
+    capfile = Helpers::Capistrano.generate_capfile({
+      bugsnag_api_key: "this is a test key",
+      app_version: "1",
+      bugsnag_auto_assign_release: true,
+      bugsnag_builder: "bob",
+      bugsnag_metadata: { a: 1, b: 2 },
+      bugsnag_env: "test",
+      current_revision: "test1234",
+      repo_url: "test@repo.com:test/test_repo.git",
+      bugsnag_repo_url: "https://repo.com/test/test_repo.git",
+      bugsnag_source_control_provider: "github",
+      bugsnag_endpoint: server.url,
+    })
+
+    Helpers::Capistrano.run(capfile)
+
+    payload = server.last_request
+
+    expect(payload["apiKey"]).to eq('this is a test key')
+    expect(payload["appVersion"]).to eq("1")
+    expect(payload["autoAssignRelease"]).to eq(true)
+    expect(payload["builderName"]).to eq("bob")
+    expect(payload["buildTool"]).to eq("bugsnag-capistrano")
+    expect(payload["metadata"]).to eq({ "a" => 1, "b" => 2 })
+    expect(payload["releaseStage"]).to eq("test")
+    expect(payload["sourceControl"]).to eq({
+      "revision" => "test1234",
+      "repository" => "https://repo.com/test/test_repo.git",
+      "provider" => "github",
+    })
+  end
 end

--- a/spec/helpers/capistrano.rb
+++ b/spec/helpers/capistrano.rb
@@ -18,5 +18,54 @@ module Helpers
 
       File.join(File.dirname(__FILE__), fixture_path)
     end
+
+    def self.generate_capfile(variables)
+      return generate_v2_capfile(variables) if version_2?
+
+      capfile = <<-RUBY.gsub(/^\s+/, "")
+        require "capistrano/setup"
+
+        require "capistrano/deploy"
+        require "capistrano/scm/git"
+        install_plugin Capistrano::SCM::Git
+
+        require "bugsnag-capistrano"
+      RUBY
+
+      # add calls to set each variable - "set(:key, value)"
+      variables.each do |key, value|
+        capfile << "set(:#{key}, #{value.inspect})\n"
+      end
+
+      capfile
+    end
+
+    def self.generate_v2_capfile(variables)
+      capfile = "require 'bugsnag-capistrano'\n"
+
+      # add calls to set each variable - "set(:key, value)"
+      variables.each do |key, value|
+        capfile << "set(:#{key}, #{value.inspect})\n"
+      end
+
+      # add an empty deploy task
+      capfile << "task :deploy do\nend"
+
+      capfile
+    end
+
+    def self.run(capfile)
+      Dir.mktmpdir do |path|
+        FileUtils.cp_r("#{example_path}/.", path)
+
+        File.open("#{path}/Capfile", "w") do |file|
+          file.write(capfile)
+        end
+
+        Dir.chdir(path) do
+          system(deploy_command)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Goal

This is #22 rebased with the new CI & test changes (#23 & #24), and tests to check the precedence of the repo URLs

This PR also adds the ability to write tests using different Capfiles without having to create entirely new fixtures. This works by copying the existing fixture into a temporary directory, updating its Capfile and running Capistrano